### PR TITLE
Document console_log_enabled flag

### DIFF
--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -21,6 +21,11 @@
 #     # The Ironic driver for nodes of this type. If not set,
 #     # `default_ironic_driver` will be used.
 #     ironic_driver: ipmi
+#     # If true, log the nodes' console output to files in `log_directory`,
+#     # instead of to a PTY. If false, direct terminal output to a PTY at
+#     # serial port 0. If not set, the stackhpc.libvirt-vm role will handle the
+#     # default behaviour.
+#     console_log_enabled: false
 node_types: {}
 
 # specs is a list of configurations of nodes to be created. Each configuration


### PR DESCRIPTION
This flag is present in the libvirt-vm role, so will be passed through
if specified in Tenks. Document it in Tenks so it can be used if needed.