### PR TITLE
Prefix volume names with node name

### DIFF
--- a/ansible/action_plugins/tenks_update_state.py
+++ b/ansible/action_plugins/tenks_update_state.py
@@ -173,6 +173,11 @@ class ActionModule(ActionBase):
                 hostname, idx = scheduler.choose_host(node)
                 # Set node name based on its index.
                 node['name'] = "%s%d" % (self.args['node_name_prefix'], idx)
+                # Sequentially number the volume names.
+                for vol_idx, vol in enumerate(node['volumes']):
+                    vol['name'] = ("%s%s%d"
+                                   % (node['name'],
+                                      self.args['vol_name_prefix'], vol_idx))
                 # Set IPMI port using its index as an offset from the lowest
                 # port.
                 node['ipmi_port'] = (
@@ -196,10 +201,6 @@ class ActionModule(ActionBase):
         )
         # Set the type name, for future reference.
         node['type'] = type_name
-        # Sequentially number the volume names.
-        for vol_idx, vol in enumerate(node['volumes']):
-            vol['name'] = (
-                "%s%d" % (self.args['vol_name_prefix'], vol_idx))
         # Ironic config is not mandatory.
         if ironic_config:
             node['ironic_config'] = ironic_config

--- a/tests/test_tenks_update_state.py
+++ b/tests/test_tenks_update_state.py
@@ -173,7 +173,7 @@ class TestTenksUpdateState(unittest.TestCase):
         for node in nodes:
             self.assertEqual(len(node['volumes']), 2)
             for n in {'0', '1'}:
-                self.assertIn('test_vol_pfx' + n,
+                self.assertIn(node['name'] + 'test_vol_pfx' + n,
                               [vol['name'] for vol in node['volumes']])
             for c in {'10GB', '20GB'}:
                 self.assertIn(c, [vol['capacity'] for vol in node['volumes']])


### PR DESCRIPTION
Each node needs its own volume, so to ensure separate volumes are
created for every node, give each volume a unique name comprising the
parent node's name and the volume's index within the node's volume list.