### PR TITLE
Allow deploy_kernel/ramdisk names to be specified

### DIFF
--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -91,10 +91,10 @@ specs: []
 #     custom_specs: {}
 nova_flavors: []
 
-# The Glance UUID of the image to use for the deployment kernel.
-deploy_kernel_uuid:
-# The Glance UUID of the image to use for the deployment ramdisk.
-deploy_ramdisk_uuid:
+# The Glance name or UUID of the image to use for the deployment kernel.
+deploy_kernel:
+# The Glance name or UUID of the image to use for the deployment ramdisk.
+deploy_ramdisk:
 
 # The path to the file which contains the state of the current Tenks cluster
 # that is deployed. This includes details such as allocations of nodes to

--- a/ansible/node_enrolment.yml
+++ b/ansible/node_enrolment.yml
@@ -12,20 +12,30 @@
           credentials exist in your environment, perhaps by sourcing your RC file.
       when: not lookup('env', 'OS_USERNAME')
 
+    # This command will return the UUIDs, regardless of whether deploy_kernel
+    # and deploy_ramdisk are image UUIDs or names.
+    - name: Get OpenStack deployment image UUIDs
+      command: >-
+        '{{ virtualenv_path }}/bin/openstack' image show
+          '{{ item }}' --format value --column id
+      loop:
+        - "{{ deploy_kernel }}"
+        - "{{ deploy_ramdisk }}"
+      # deploy_kernel/ramdisk default to none. We don't need to know them for
+      # enrolment to continue.
+      when: item is not none
+      register: deploy_image_ids
+      changed_when: false
+
     - name: Perform Ironic enrolment for each hypervisor's nodes
       include_role:
         name: ironic-enrolment
       vars:
-        ironic_deploy_kernel_uuid: "{{ deploy_kernel_uuid }}"
-        ironic_deploy_ramdisk_uuid: "{{ deploy_ramdisk_uuid }}"
-        # FIXME(w-miller): Set absent/present in tenks_schedule on a per-node
-        # basis to account for existing allocations, rather than for all nodes
-        # here.
-        ironic_nodes: >-
-          {{ alloc.value.nodes
-               | map('combine', {'state': ('absent' if cmd == 'teardown'
-                                           else 'present')})
-               | list }}
+        ironic_deploy_kernel_uuid: >-
+          {{ deploy_image_ids.results.0.stdout | default(omit) }}
+        ironic_deploy_ramdisk_uuid: >-
+          {{ deploy_image_ids.results.1.stdout | default(omit) }}
+        ironic_nodes: "{{ alloc.value.nodes }}"
         ironic_hypervisor: "{{ alloc.key }}"
         ironic_virtualenv_path: "{{ virtualenv_path }}"
         ironic_python_upper_constraints_url: >-

--- a/ansible/override.yml.example
+++ b/ansible/override.yml.example
@@ -36,6 +36,20 @@ specs:
       # Required if `ironic_config` has been specified.
       resource_class: my_rc
 
+# nova_flavors is a list of Nova flavors to be created. Each flavor must
+# specify the resource class it is associated with, as well as the Tenks node
+# type whose hardware specs should be used.
+nova_flavors:
+    # Required.
+  - resource_class: my_rc
+    # Required.
+    node_type: type0
+
+# The Glance name or UUID of the image to use for the deployment kernel.
+deploy_kernel: ipa.vmlinuz
+# The Glance name or UUID of the image to use for the deployment ramdisk.
+deploy_ramdisk: ipa.initramfs
+
 # Map physical network names to their source device. This can be either an
 # existing interface or an existing bridge.
 # Remember that if the mappings are specified in this file, they will apply to

--- a/ansible/roles/ironic-enrolment/tasks/node.yml
+++ b/ansible/roles/ironic-enrolment/tasks/node.yml
@@ -31,11 +31,11 @@
       set_fact:
         nics: "{{ nics | union([{'mac': item.split()[4]}]) }}"
       loop: "{{ iflist_res.stdout_lines[2:] }}"
-      when: node.state == 'present'
+      when: (node.state | default('present')) == 'present'
 
   # If the node's state is 'absent', the domain will already have been
   # destroyed.
-  when: node.state == 'present'
+  when: (node.state | default('present')) == 'present'
 
 - name: Configure node in Ironic
   os_ironic:
@@ -54,7 +54,7 @@
     name: "{{ node.name }}"
     # The 'nics' list can be empty without a problem if state is 'absent'.
     nics: "{{ nics | default([]) }}"
-    state: "{{ node.state }}"
+    state: "{{ node.state | default('present') }}"
   vars:
     # This module requires the openstacksdk package, which is installed within
     # our virtualenv.
@@ -109,4 +109,4 @@
         '{{ ironic_virtualenv_path }}/bin/openstack' baremetal node maintenance
           unset '{{ node_res.uuid }}'
 
-  when: node.state == 'present'
+  when: (node.state | default('present')) == 'present'


### PR DESCRIPTION
You can now use either a name or a UUID for these images. Also, remove
the unnecessary setting of node states, which is now handled by the
scheduling plugin.