### PR TITLE
Move deploy image ID finding to enrolment role

### DIFF
--- a/ansible/node_enrolment.yml
+++ b/ansible/node_enrolment.yml
@@ -12,29 +12,12 @@
           credentials exist in your environment, perhaps by sourcing your RC file.
       when: not lookup('env', 'OS_USERNAME')
 
-    # This command will return the UUIDs, regardless of whether deploy_kernel
-    # and deploy_ramdisk are image UUIDs or names.
-    - name: Get OpenStack deployment image UUIDs
-      command: >-
-        '{{ virtualenv_path }}/bin/openstack' image show
-          '{{ item }}' --format value --column id
-      loop:
-        - "{{ deploy_kernel }}"
-        - "{{ deploy_ramdisk }}"
-      # deploy_kernel/ramdisk default to none. We don't need to know them for
-      # enrolment to continue.
-      when: item is not none
-      register: deploy_image_ids
-      changed_when: false
-
     - name: Perform Ironic enrolment for each hypervisor's nodes
       include_role:
         name: ironic-enrolment
       vars:
-        ironic_deploy_kernel_uuid: >-
-          {{ deploy_image_ids.results.0.stdout | default(omit) }}
-        ironic_deploy_ramdisk_uuid: >-
-          {{ deploy_image_ids.results.1.stdout | default(omit) }}
+        ironic_deploy_kernel: "{{ deploy_kernel }}"
+        ironic_deploy_ramdisk: "{{ deploy_ramdisk }}"
         ironic_nodes: "{{ alloc.value.nodes }}"
         ironic_hypervisor: "{{ alloc.key }}"
         ironic_virtualenv_path: "{{ virtualenv_path }}"

--- a/ansible/roles/ironic-enrolment/defaults/main.yml
+++ b/ansible/roles/ironic-enrolment/defaults/main.yml
@@ -3,10 +3,10 @@
 ironic_nodes: []
 # The hostname of the hypervisor where these nodes exist.
 ironic_hypervisor:
-# The Glance UUID of the image to use for the deployment kernel.
-ironic_deploy_kernel_uuid:
-# The Glance UUID of the image to use for the deployment ramdisk.
-ironic_deploy_ramdisk_uuid:
+# The Glance name or UUID of the image to use for the deployment kernel.
+ironic_deploy_kernel:
+# The Glance name UUID of the image to use for the deployment ramdisk.
+ironic_deploy_ramdisk:
 # The path to the virtualenv in which to install the OpenStack clients.
 ironic_virtualenv_path:
 # The URL of the upper constraints file to pass to pip when installing Python

--- a/ansible/roles/ironic-enrolment/tasks/main.yml
+++ b/ansible/roles/ironic-enrolment/tasks/main.yml
@@ -16,12 +16,31 @@
       -c {{ ironic_python_upper_constraints_url }}
     virtualenv: "{{ ironic_virtualenv_path }}"
 
+# This command will return the UUIDs, regardless of whether
+# ironic_deploy_kernel and ironic_deploy_ramdisk are image UUIDs or names.
+- name: Get OpenStack deployment image UUIDs
+  command: >-
+    '{{ ironic_virtualenv_path }}/bin/openstack' image show
+      '{{ item }}' --format value --column id
+  loop:
+    - "{{ ironic_deploy_kernel }}"
+    - "{{ ironic_deploy_ramdisk }}"
+  # ironic_deploy_kernel/ramdisk default to none. We don't need to know them
+  # for enrolment to continue.
+  when: item is not none
+  register: deploy_image_ids
+  changed_when: false
+
 - name: Configure Ironic node enrolment
   include_tasks: node.yml
   vars:
     node: "{{ ironic_node }}"
     ipmi_port: >-
       {{ hostvars[ironic_hypervisor].ipmi_port_range_start + port_offset }}
+    ironic_deploy_kernel_uuid: >-
+      {{ deploy_image_ids.results.0.stdout | default(ironic_deploy_kernel) }}
+    ironic_deploy_ramdisk_uuid: >-
+      {{ deploy_image_ids.results.1.stdout | default(ironic_deploy_ramdisk) }}
   loop: "{{ ironic_nodes | sort(attribute='name') }}"
   loop_control:
     loop_var: ironic_node


### PR DESCRIPTION
The OpenStack client Python package is not necessarily installed in the
Tenks virtualenv until the role is run, so we need to query OpenStack
for the image IDs inside the role.