### PR TITLE
Reorder installation steps

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -56,14 +56,14 @@ Obtain the Tenks source code and change into the directory. For example::
   (tenks) $ git clone https://github.com/stackhpc/tenks.git
   (tenks) $ cd tenks
 
+Install Tenks and its requirements using the source code checkout::
+
+  (tenks) $ pip install .
+
 Tenks has dependencies on Ansible roles that are hosted by Ansible Galaxy.
 These can be installed by a command such as::
 
   (tenks) $ ansible-galaxy install --role-file=requirements.yml --roles-path=ansible/roles/
-
-Install Tenks and its requirements using the source code checkout::
-
-  (tenks) $ pip install .
 
 If you now wish to run Tenks (see :ref:`run`), keep your virtualenv active. If
 not, deactivate it::


### PR DESCRIPTION
Tenks has a dependency on ansible. We need to make sure this is installed
before we run `ansible-galaxy install`. `pip install .` was therefore moved
above `ansible-galaxy install` in the installation steps.