### PR TITLE
Use package instead of yum

### DIFF
--- a/ansible/hypervisor_setup.yml
+++ b/ansible/hypervisor_setup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure general system requirements are installed
-  yum:
+  package:
     name: "{{ system_requirements }}"
   become: true
   # Don't uninstall requirements during teardown since they may already have


### PR DESCRIPTION
This is with the view that tenks should support multiple
GNU/Linux distributions. The package module abstracts
over the differences between package managers.