### PR TITLE
Support Debian based GNU/Linux distributions

### DIFF
--- a/ansible/roles/virtualbmc-daemon/defaults/main.yml
+++ b/ansible/roles/virtualbmc-daemon/defaults/main.yml
@@ -1,9 +1,4 @@
 ---
-# List of package dependencies to install.
-# TODO: Make platform-independent.
-vbmcd_packages:
-  - gcc
-  - libvirt-devel
 # The path to the virtualenv in which to install Virtual BMC.
 vbmcd_virtualenv_path:
 # The URL of the upper constraints file to pass to pip when installing Python

--- a/ansible/roles/virtualbmc-daemon/tasks/main.yml
+++ b/ansible/roles/virtualbmc-daemon/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      skip: true
+  tags: vars
+
 - name: Ensure package dependencies are installed
   package:
     name: "{{ item }}"

--- a/ansible/roles/virtualbmc-daemon/vars/Debian.yml
+++ b/ansible/roles/virtualbmc-daemon/vars/Debian.yml
@@ -1,0 +1,5 @@
+---
+# List of package dependencies to install.
+vbmcd_packages:
+  - gcc
+  - libvirt-dev

--- a/ansible/roles/virtualbmc-daemon/vars/RedHat.yml
+++ b/ansible/roles/virtualbmc-daemon/vars/RedHat.yml
@@ -1,0 +1,5 @@
+---
+# List of package dependencies to install.
+vbmcd_packages:
+  - gcc
+  - libvirt-devel


### PR DESCRIPTION
- use package module instead of yum
- libvirt-devel is called libvirt-dev on debian based distributions