### PR TITLE
ovs-vsctl list-br requires root privileges

### DIFF
--- a/ansible/physical_network.yml
+++ b/ansible/physical_network.yml
@@ -28,6 +28,7 @@
       command: ovs-vsctl list-br
       register: ovs_bridges
       changed_when: false
+      become: true
 
     - name: Register source interface as an Open vSwitch bridge
       set_fact:


### PR DESCRIPTION
At least this is the case on ubuntu:

(.venv) stack@ubuntu:~/tenks$ ovs-vsctl list-br
ovs-vsctl: unix:/var/run/openvswitch/db.sock: database connection failed (Permission denied)