### PR TITLE
Use /usr/bin/virsh instead of /bin/virsh

### DIFF
--- a/ansible/roles/ironic-enrolment/README.md
+++ b/ansible/roles/ironic-enrolment/README.md
@@ -11,7 +11,7 @@ Requirements
   the shell environment. These can be sourced from an OpenStack RC file, for
   example.
 
-- The `virsh` command-line tool present at `/bin/virsh`.
+- The `virsh` command-line tool present at `/usr/bin/virsh`.
 
 Role Variables
 --------------

--- a/ansible/roles/ironic-enrolment/tasks/node.yml
+++ b/ansible/roles/ironic-enrolment/tasks/node.yml
@@ -12,9 +12,7 @@
       # The output format of this command gives two lines of header, followed by
       # (for each vNIC):
       # <name> <type> <source interface> <model> <MAC>
-      # The VMs will have been created with the virt module, using become: true.
-      # This targets /bin/virsh rather than /usr/bin/virsh.
-      command: /bin/virsh domiflist '{{ node.name }}'
+      command: /usr/bin/virsh domiflist '{{ node.name }}'
       register: iflist_res
       changed_when: false
       become: true


### PR DESCRIPTION
On RedHat based distros /bin/ is a symlink to /usr/bin:

[will@dev-director ~]$ ls -lia /bin
410146 lrwxrwxrwx. 1 root root 7 Jun 11 12:07 /bin -> usr/bin

Whereas on the Ubuntu it is seperate directory. Using
/usr/bin/virsh should work on both.

ubuntu:

stack@ubuntu:~/ansible-role-libvirt-vm$ whereis virsh
virsh: /usr/bin/virsh /usr/share/man/man1/virsh.1

centos:

[will@dev-director ~]$ whereis virsh
virsh: /usr/bin/virsh /usr/share/man/man1/virsh.1.gz

Also removed a misleading comment. QEMU uses differnt
"instances" for privaleged and user access i.e the
"system" and "session" instances. The comment seemed
to suggest using /bin/virsh would connect to the
system instance (at least that is how I read it).