### PR TITLE
ip on RedHat based distros is at /usr/sbin/ip

### DIFF
--- a/ansible/vars/RedHat.yml
+++ b/ansible/vars/RedHat.yml
@@ -1,4 +1,4 @@
 ---
 
 # path to `ip` from the `iproute2` package
-tenks_ip_path: /usr/bin/ip
+tenks_ip_path: /usr/sbin/ip


### PR DESCRIPTION
I had accidentally used the wrong path when I added support for ubuntu.