### PR TITLE
Add support for EFI boot mode

### DIFF
--- a/ansible/host_setup.yml
+++ b/ansible/host_setup.yml
@@ -18,7 +18,7 @@
     nodes: >-
       {{ hostvars.localhost.tenks_state[inventory_hostname].nodes
            | default([]) }}
-    libvirt_enable_efi_default: "{{ 'efi' in (nodes | map(attribute='boot_firmware') | map('lower')) }}"    
+    libvirt_enable_efi_default: "{{ 'efi' in (nodes | map(attribute='boot_firmware') | map('lower')) }}"
   tasks:
     - block:
         - name: Configure host for Libvirt

--- a/ansible/host_setup.yml
+++ b/ansible/host_setup.yml
@@ -14,6 +14,11 @@
     - include_tasks: hypervisor_setup.yml
 
 - hosts: libvirt
+  vars:
+    nodes: >-
+      {{ hostvars.localhost.tenks_state[inventory_hostname].nodes
+           | default([]) }}
+    libvirt_enable_efi_default: "{{ 'efi' in (nodes | map(attribute='boot_firmware') | map('lower')) }}"    
   tasks:
     - block:
         - name: Configure host for Libvirt
@@ -29,6 +34,7 @@
                 owner: "{{ libvirt_pool_owner }}"
                 group: "{{ libvirt_pool_group }}"
             libvirt_host_require_vt: "{{ libvirt_require_vt }}"
+            libvirt_host_enable_efi_support: "{{ libvirt_enable_efi | default(libvirt_enable_efi_default) }}"
 
         - name: Set up Virtual BMC daemon
           include_role:

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -14,7 +14,9 @@ cmd: deploy
 #     memory_mb: 1024
 #     # The number of virtual CPUs.
 #     vcpus: 2
-#     # A list of volumes, each with a capacity.
+#     # The boot firmware to use. Can be one of: bios, or efi.
+#     boot_firmware: bios
+#     # A list of volumes, each with a capacity.#
 #     volumes:
 #       - capacity: 2GB
 #     # A list of physical network names to connect to. These physical network


### PR DESCRIPTION
This requires upstream support in stackhpc.libvirt-host
and stackhpc.libvirt-vm, see:

- stackhpc/ansible-role-libvirt-vm#12
- stackhpc/ansible-role-libvirt-host#7