### PR TITLE
Fix lint warning concerning task names

### DIFF
--- a/ansible/physical_network.yml
+++ b/ansible/physical_network.yml
@@ -20,7 +20,8 @@
 ### Firstly, some fact gathering.
 # Start off by assuming the source interface is direct, unless proven
 # otherwise.
-- set_fact:
+- name: Set initial value for source_type
+  set_fact:
     source_type: direct
 
 - name: Get source interface details


### PR DESCRIPTION
```
[502] All tasks should be named
/home/will/code/tenks/ansible/physical_network.yml:23
Task/Handler: set_fact source_type=direct __line__=24 __file__=/home/will/code/tenks/ansible/physical_network.yml
```