### PR TITLE
Only set Ironic port attributes when changed

### DIFF
--- a/ansible/roles/ironic-enrolment/tasks/port.yml
+++ b/ansible/roles/ironic-enrolment/tasks/port.yml
@@ -22,6 +22,7 @@
     {{ ironic_virtualenv_path }}/bin/openstack baremetal port show
       {{ uuid.stdout }} -f json
   register: port_attributes_output
+  changed_when: false
 
 - name: Set Ironic port attributes
   vars:

--- a/ansible/roles/ironic-enrolment/tasks/port.yml
+++ b/ansible/roles/ironic-enrolment/tasks/port.yml
@@ -17,14 +17,29 @@
   set_fact:
     bridge: "{{ physnet | bridge_name }}"
 
+- name: Get existing Ironic port attributes
+  command: >-
+    {{ ironic_virtualenv_path }}/bin/openstack baremetal port show
+      {{ uuid.stdout }} -f json
+  register: port_attributes_output
+
 - name: Set Ironic port attributes
+  vars:
+    port_attributes: "{{ port_attributes_output.stdout | from_json }}"
+    switch_id: "{{ hostvars[ironic_hypervisor]['ansible_' + bridge].macaddress
+    switch_info: "{{ bridge }}"
+    port_id: >-
+      {{ source_interface
+        | source_to_ovs_link_name(inventory_hostname=ironic_hypervisor) }}
   command: >-
     '{{ ironic_virtualenv_path }}/bin/openstack' baremetal port set
       {{ uuid.stdout }}
       --physical-network '{{ physnet }}'
-      --local-link-connection switch_id='{{ hostvars[ironic_hypervisor][
-                                              'ansible_' + bridge
-                                              ].macaddress }}'
+      --local-link-connection switch_id='{{ switch_id }}'
       --local-link-connection switch_info='{{ bridge }}'
-      --local-link-connection port_id='{{ source_interface
-        | source_to_ovs_link_name(inventory_hostname=ironic_hypervisor) }}'
+      --local-link-connection port_id='{{ port_id }}'
+  when: >-
+    port_attributes.physical_network != physnet or
+    port_attributes.local_link_connection.switch_id != switch_id or
+    port_attributes.local_link_connection.switch_info != switch_info or
+    port_attributes.local_link_connection.port_id != port_id

--- a/ansible/roles/ironic-enrolment/tasks/port.yml
+++ b/ansible/roles/ironic-enrolment/tasks/port.yml
@@ -26,7 +26,7 @@
 - name: Set Ironic port attributes
   vars:
     port_attributes: "{{ port_attributes_output.stdout | from_json }}"
-    switch_id: "{{ hostvars[ironic_hypervisor]['ansible_' + bridge].macaddress
+    switch_id: "{{ hostvars[ironic_hypervisor]['ansible_' + bridge].macaddress }}"
     switch_info: "{{ bridge }}"
     port_id: >-
       {{ source_interface


### PR DESCRIPTION
This fixes a lint issue:

[301] Commands should not change things if nothing needs doing
/home/will/code/tenks/ansible/roles/ironic-enrolment/tasks/port.yml:20
Task/Handler: Set Ironic port attributes