### PR TITLE
Use extend-ignore in preference to ignore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,6 @@ commands = bash -c "ansible-lint \
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125
+extend-ignore = E123,E125
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
The behavior of flake has changed so that ignore overwrites the
default list. This uses the new extend-ignore option to emulate
the old behavior.

See: https://gitlab.com/pycqa/flake8/issues/466 for more details.